### PR TITLE
Fix docker port

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ $ # (Powershell) $env:FLASK_ENV = "development"
 $
 $ # Start the application (development mode)
 $ # --host=0.0.0.0 - expose the app on all network interfaces (default 127.0.0.1)
-$ # --port=5000    - specify the app port (default 5000)  
-$ flask run --host=0.0.0.0 --port=5000
+$ # --port=5005    - specify the app port (default 5000)  
+$ flask run --host=0.0.0.0 --port=5005
 $
-$ # Access the dashboard in browser: http://127.0.0.1:5000/
+$ # Access the dashboard in browser: http://127.0.0.1:5005/
 ```
 
 <br />
@@ -95,7 +95,7 @@ $ cd flask-dashboard-material-dark
 $ sudo docker-compose pull && sudo docker-compose build && sudo docker-compose up -d
 ```
 
-Visit `http://localhost:5000` in your browser. The app should be up & running.
+Visit `http://localhost:5005` in your browser. The app should be up & running.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ # (Powershell) $env:FLASK_ENV = "development"
 $
 $ # Start the application (development mode)
 $ # --host=0.0.0.0 - expose the app on all network interfaces (default 127.0.0.1)
-$ # --port=5005    - specify the app port (default 5000)  
+$ # --port=5005    - specify the app port (default 5005)  
 $ flask run --host=0.0.0.0 --port=5005
 $
 $ # Access the dashboard in browser: http://127.0.0.1:5005/


### PR DESCRIPTION
Port `5000` should be `5005` due to the configurations set in this repo, which can easily be seen with `grep -R 5005` from the repo root:

```
# grep -R 5005
gunicorn-cfg.py:bind = '0.0.0.0:5005'
docker-compose.yml:      - "5005:5005"
nginx/appseed-app.conf:        proxy_pass http://localhost:5005/;
app/base/static/assets/scss/material-dashboard/variables/_colors.scss:$pink-a400: #f50057 !default;
Dockerfile:EXPOSE 5005
```

The following all reference port `5005`:
- docker-compose
- Dockerfile
- gunicorn
- nginx/appseed-app.conf

Listing port 5000 in the readme is incorrect, it should be 5005.

Attempting a similar `grep -R 5000` shows:

```
# grep -R 5000
README.md:$ # --port=5000    - specify the app port (default 5000)  
README.md:$ flask run --host=0.0.0.0 --port=5000
README.md:$ # Access the dashboard in browser: http://127.0.0.1:5000/
README.md:Visit `http://localhost:5000` in your browser. The app should be up & running.
app/base/static/assets/scss/material-dashboard/variables/_colors.scss:$red-a700: #d50000 !default;
app/base/static/assets/js/plugins/bootstrap-notify.js:    delay: 5000,
```

Those are all unrelated to a port listening or exposed at port `5000`, other than the incorrect README directions.